### PR TITLE
Fix error when using .gz files on Mac

### DIFF
--- a/miRScore
+++ b/miRScore
@@ -549,7 +549,7 @@ def align_fastqs(args, files):
 
         if is_gz:
             cmd = (
-                f"zcat {file} | "
+                f"gunzip -c {file} | "
                 f"bowtie -p {args.threads} -a {mismatch_option} --no-unal --norc -S -x hairpin -q - | "
                 f"samtools view -Sb - > alignments/{file_core}.bam"
             )

--- a/miRScore
+++ b/miRScore
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-version = '0.3.6'
+version = '0.3.7'
 
 import RNA, re, pysam, gzip
 from pysam import FastaFile


### PR DESCRIPTION
miRScore previously used `zcat` to convert fastq.gz to a decompressed stream. That does not work on standard Mac devices because of differences in `zcat` versions; use of fastq.gz files on a Mac with old miRScore will crash the run. A safer way is to use `gunzip -c`, which will create the desired stream on any device.

This pull request also updates the hard-coded version number to 0.3.7.

Note that the last release was 0.3.5. Consider making a tag and official release, else these changes will not propagate to bioconda recipe. 

If you want me to take over this script, just let me know.